### PR TITLE
Hide result form parts depending on parent result

### DIFF
--- a/app/controllers/decidim/accountability/admin/results_controller.rb
+++ b/app/controllers/decidim/accountability/admin/results_controller.rb
@@ -9,6 +9,7 @@ module Decidim
 
         def new
           @form = form(ResultForm).instance
+          @form.parent_id = params[:parent_id]
         end
 
         def create

--- a/app/views/decidim/accountability/admin/results/_form.html.erb
+++ b/app/views/decidim/accountability/admin/results/_form.html.erb
@@ -12,20 +12,25 @@
       <%= form.translated :editor, :description %>
     </div>
 
-    <% if !@form.process_scope %>
-    <div class="row column">
-        <%= form.collection_select :decidim_scope_id, organization_scopes, :id, :name %>
+    <% if @form.parent_id %>
+
+      <div class="row column">
+        <%= form.select :parent_id, parent_results.map{|result| [translated_attribute(result.title), result.id] }, include_blank: true %>
       </div>
+
+    <% else %>
+
+      <% if !@form.process_scope %>
+        <div class="row column">
+          <%= form.collection_select :decidim_scope_id, organization_scopes, :id, :name %>
+        </div>
+      <% end %>
+
+      <div class="row column">
+        <%= form.categories_select :decidim_category_id, current_participatory_process.categories, include_blank: true, disable_parents: false %>
+      </div>
+
     <% end %>
-
-    <div class="row column">
-      <%= form.categories_select :decidim_category_id, current_participatory_process.categories, include_blank: true, disable_parents: false %>
-    </div>
-
-    <div class="row column">
-      <%= form.label :parent_id %>
-      <%= select :result, :parent_id, parent_results.map{|result| [translated_attribute(result.title), result.id] }, include_blank: true %>
-    </div>
 
     <div class="row">
       <div class="columns xlarge-6">
@@ -39,8 +44,7 @@
 
     <div class="row">
       <div class="columns xlarge-6">
-        <%= form.label :status %>
-        <%= select :result, :decidim_accountability_status_id, statuses.map{|status| [translated_attribute(status.name), status.id] }, include_blank: true %>
+        <%= form.select :decidim_accountability_status_id, statuses.map{|status| [translated_attribute(status.name), status.id] }, include_blank: true %>
       </div>
 
       <div class="columns xlarge-6">


### PR DESCRIPTION
In the result form show category and scope select for first level results and parent for second level results