### PR TITLE
CSV importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 The Accountability module adds results to any participatory process. It adds a CRUD engine to the admin and public views scoped inside the participatory process. Accountability will link to related meetings and proposals and will be used to show the progress on the related proposals.
 
+It also has a CSV importer for results, you can read [here](doc/csv_importer.md) about how it works, the CSV columns and what they mean.
+
 ## Usage
 Accountability will be available as a Feature for a Participatory Process.
 

--- a/app/commands/decidim/accountability/admin/create_result.rb
+++ b/app/commands/decidim/accountability/admin/create_result.rb
@@ -37,6 +37,7 @@ module Decidim
             parent_id: @form.parent_id,
             title: @form.title,
             description: @form.description,
+            external_id: @form.external_id,
             start_date: @form.start_date,
             end_date: @form.end_date,
             progress: @form.progress,

--- a/app/commands/decidim/accountability/admin/update_result.rb
+++ b/app/commands/decidim/accountability/admin/update_result.rb
@@ -41,6 +41,7 @@ module Decidim
             parent_id: @form.parent_id,
             title: @form.title,
             description: @form.description,
+            external_id: @form.external_id,
             start_date: @form.start_date,
             end_date: @form.end_date,
             progress: @form.progress,

--- a/app/controllers/decidim/accountability/admin/imports_controller.rb
+++ b/app/controllers/decidim/accountability/admin/imports_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Accountability
+    module Admin
+      # This controller allows an admin to import results from a csv file for the Accountability feature
+      class ImportsController < Admin::ApplicationController
+
+        def new
+          @errors = []
+        end
+
+        def create
+          @csv_file = params[:csv_file]
+          redirect_to new_import_path and return unless @csv_file.present?
+
+          i = CSVImporter.new(current_feature, @csv_file.path)
+          @errors = i.import!
+          if @errors.empty?
+            flash[:notice] = I18n.t("imports.create.success", scope: "decidim.accountability.admin")
+            redirect_to new_import_path
+          else
+            flash.now[:error] = I18n.t("imports.create.invalid", scope: "decidim.accountability.admin")
+            render :new
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/decidim/accountability/result.rb
+++ b/app/models/decidim/accountability/result.rb
@@ -19,6 +19,8 @@ module Decidim
 
       belongs_to :status, foreign_key: "decidim_accountability_status_id", class_name: Decidim::Accountability::Status, inverse_of: :results
 
+      before_validation :remove_blank_values
+
       after_save :update_parent_progress, if: -> { parent_id.present? }
 
       def update_parent_progress
@@ -50,6 +52,12 @@ module Decidim
       # Public: Overrides the `comments_have_votes?` Commentable concern method.
       def comments_have_votes?
         true
+      end
+
+      private
+
+      def remove_blank_values
+        self.external_id = nil if external_id.blank?
       end
     end
   end

--- a/app/services/decidim/accountability/csv_importer.rb
+++ b/app/services/decidim/accountability/csv_importer.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+require "csv"
+
+module Decidim
+  module Accountability
+    # This class handles importing results from a CSV file.
+    # Needs a `current_feature` param with a `Decidim::Feature`
+    # in order to import the results in that feature.
+    class CSVImporter
+      include Decidim::FormFactory
+
+      # Public: Initializes the service.
+      # feature       - A Decidim::Feature to import the results into.
+      # csv_file_path - The path to the csv file.
+      def initialize(feature, csv_file_path)
+        @feature = feature
+        @csv_file_path = csv_file_path
+        @extra_context = { current_feature: feature, current_organization: feature.organization}
+      end
+
+      def import!
+        errors = []
+
+        ActiveRecord::Base.transaction do
+          i = 1
+          CSV.foreach(@csv_file_path, headers: true) do |row|
+            i += 1
+            next if row.empty?
+
+            params = {}
+            params["result"] = row.to_hash
+
+            if row["result_id"].present?
+              existing_result = Decidim::Accountability::Result.find_by(id: row['result_id'].to_i)
+              unless existing_result.present?
+                errors << [i, [I18n.t("imports.create.not_found", scope: "decidim.accountability.admin", result_id: row["result_id"])]]
+                next
+              end
+            elsif row["external_id"].present?
+              existing_result = Decidim::Accountability::Result.find_by(external_id: row["external_id"])
+              params["result"]["id"] = existing_result.id if existing_result
+            end
+
+            if row["parent_id"].blank? && row["parent_external_id"].present?
+              if parent = Decidim::Accountability::Result.find_by(external_id: row["parent_external_id"])
+                params["result"]["parent_id"] = parent.id
+              end
+            end
+
+            @form = form(Decidim::Accountability::Admin::ResultForm).from_params(params, @extra_context)
+
+            begin
+              start_date = Date.parse(row["start_date"]) if row["start_date"].present?
+            rescue ArgumentError
+              @form.errors.add(:start_date, :invalid_date)
+            end
+
+            begin
+              end_date = Date.parse(row["end_date"]) if row["end_date"].present?
+            rescue ArgumentError
+              @form.errors.add(:end_date, :invalid_date)
+            end
+
+            # add form errors now because when calling valid on the form in UpdateResult/CreateResult will clear the errors
+            errors << [i, @form.errors.full_messages] if @form.errors.any?
+
+            if existing_result #update existing result
+              Decidim::Accountability::Admin::UpdateResult.call(@form, existing_result) do
+                on(:invalid) do
+                  errors << [i, @form.errors.full_messages]
+                end
+              end
+            else #create new result
+              Decidim::Accountability::Admin::CreateResult.call(@form) do
+                on(:invalid) do
+                  errors << [i, @form.errors.full_messages]
+                end
+              end
+            end
+          end
+
+          raise ActiveRecord::Rollback if errors.any?
+        end
+
+        errors
+      end
+    end
+  end
+end

--- a/app/services/decidim/accountability/csv_importer.rb
+++ b/app/services/decidim/accountability/csv_importer.rb
@@ -47,6 +47,10 @@ module Decidim
               end
             end
 
+            if row["decidim_accountability_status_id"].present? && status = Decidim::Accountability::Status.find_by(id: row["decidim_accountability_status_id"])
+              params["result"]["progress"] = status.progress if status.progress.present?
+            end
+
             @form = form(Decidim::Accountability::Admin::ResultForm).from_params(params, @extra_context)
 
             begin

--- a/app/services/decidim/accountability/csv_importer.rb
+++ b/app/services/decidim/accountability/csv_importer.rb
@@ -51,6 +51,14 @@ module Decidim
               params["result"]["progress"] = status.progress if status.progress.present?
             end
 
+            default_locale = @feature.participatory_process.organization.default_locale
+            available_locales = @feature.participatory_process.organization.available_locales
+
+            available_locales.each do |locale|
+              params["result"]["title_#{locale}"] = params["result"]["title_#{default_locale}"] if params["result"]["title_#{locale}"].blank?
+              params["result"]["description_#{locale}"] = params["result"]["description_#{default_locale}"] if params["result"]["description_#{locale}"].blank?
+            end
+
             @form = form(Decidim::Accountability::Admin::ResultForm).from_params(params, @extra_context)
 
             begin

--- a/app/services/decidim/accountability/progress_calculator.rb
+++ b/app/services/decidim/accountability/progress_calculator.rb
@@ -5,7 +5,6 @@ module Decidim
     # This class handles the calculation of progress for a set of results
     class ProgressCalculator
       # Public: Initializes the service.
-      # result - The result from which to calculate the stats.
       def initialize(feature, scope_id, category_id)
         @feature = feature
         @scope_id = scope_id

--- a/app/views/decidim/accountability/admin/imports/new.html.erb
+++ b/app/views/decidim/accountability/admin/imports/new.html.erb
@@ -1,0 +1,44 @@
+<%= form_tag({:action => :create}, multipart: true, class: "form new_import") do %>
+  <div class="card">
+    <div class="card-divider">
+      <h2 class="card-title"><%= t(".title") %></h2>
+    </div>
+
+    <% unless @errors.empty? %>
+      <div class="card-section">
+        <div class="row column">
+          <table>
+            <thead>
+              <tr>
+                <th><%= t(".row_number") %></th>
+                <th><%= t(".errors") %></th>
+              </tr>
+            </thead>
+            <% @errors.each do |error| %>
+              <tr>
+                <td><%= error.first %></td>
+                <td>
+                  <ul>
+                    <% error.last.each do |error_message| %>
+                      <li><%= error_message %></li>
+                    <% end %>
+                  </ul>
+                </td>
+              </tr>
+            <% end %>
+          </table>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="card-section">
+      <div class="row column">
+        <%= file_field_tag :csv_file %>
+      </div>
+    </div>
+  </div>
+
+  <div class="button--double form-general-submit">
+    <%= submit_tag t(".import"), class: "button" %>
+  </div>
+<% end %>

--- a/app/views/decidim/accountability/admin/shared/_subnav.html.erb
+++ b/app/views/decidim/accountability/admin/shared/_subnav.html.erb
@@ -2,4 +2,5 @@
   <li><%= link_to t(".results"), results_path %></li>
   <li><%= link_to t(".statuses"), statuses_path %></li>
   <li><%= link_to t(".template_texts"), edit_template_texts_path %></li>
+  <li><%= link_to t(".import_csv"), new_import_path %></li>
 </ul>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -7,3 +7,4 @@ ignore_unused:
 - "decidim.accountability.models.project.valid_statuses.*"
 - activerecord.attributes.*
 - activemodel.attributes.*
+- activemodel.errors.*

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -11,7 +11,7 @@ ca:
         progress: Progrés
         proposal_ids: Propostes incloses
         start_date: Inici
-        status: Estat
+        decidim_accountability_status_id: Estat
         title: Títol
       status:
         description: Descripció
@@ -24,6 +24,14 @@ ca:
         heading_parent_level_results: Nom per "Resultats"
         intro: Texto de introducció
         subcategories_label: Nom per "Subcategorias"
+    errors:
+      models:
+        result:
+          attributes:
+            start_date:
+              invalid_date: no vàlida
+            end_date:
+              invalid_date: no vàlida
   decidim:
     accountability:
       actions:
@@ -34,6 +42,16 @@ ca:
         preview: Previsualitzar
         title: Accions
       admin:
+        imports:
+          create:
+            invalid: Hi ha hagut un problema en importar aquest fitxer
+            not_found: No s'ha trobat un resultat amb result_id %{result_id}
+            success: El fitxer ha estat importat correctament
+          new:
+            errors: Errors
+            import: Import
+            row_number: Fila
+            title: Importar resultats des de CSV
         models:
           result:
             name: Resultat
@@ -58,6 +76,7 @@ ca:
             success: El resultat ha estat actualitzat correctament
         shared:
           subnav:
+            import_csv: Import CSV
             results: Resultats
             statuses: Estats
             template_texts: Template Texts

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
   activemodel:
     attributes:
       result:
+        decidim_accountability_status_id: status
         decidim_category_id: Category
         decidim_scope_id: Scope
         description: Description
@@ -11,7 +12,6 @@ en:
         progress: Progress
         proposal_ids: Included proposals
         start_date: Start date
-        status: status
         title: Title
       status:
         description: Description
@@ -24,6 +24,14 @@ en:
         heading_parent_level_results: Name for "Projects"
         intro: Intro text
         subcategories_label: Name for "Subcategories"
+    errors:
+      models:
+        result:
+          attributes:
+            end_date:
+              invalid_date: is invalid
+            start_date:
+              invalid_date: is invalid
   decidim:
     accountability:
       actions:
@@ -34,6 +42,16 @@ en:
         preview: Preview
         title: Actions
       admin:
+        imports:
+          create:
+            invalid: There's been a problem importing this file
+            not_found: No result found with result_id %{result_id}
+            success: File successfully imported
+          new:
+            errors: Errors
+            import: Import
+            row_number: Row
+            title: Import results from CSV
         models:
           result:
             name: Result
@@ -58,6 +76,7 @@ en:
             success: Result successfully updated
         shared:
           subnav:
+            import_csv: Import CSV
             results: Results
             statuses: Statuses
             template_texts: Template Texts

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -11,7 +11,7 @@ es:
         progress: Progreso
         proposal_ids: Propuestas incluidas
         start_date: Inicio
-        status: Estado
+        decidim_accountability_status_id: Estado
         title: Título
       status:
         description: Descripción
@@ -24,6 +24,14 @@ es:
         heading_parent_level_results: Nombre para "Proyectos"
         intro: Texto de introducción
         subcategories_label: Nombre para "Subcategorías"
+    errors:
+      models:
+        result:
+          attributes:
+            start_date:
+              invalid_date: no válida
+            end_date:
+              invalid_date: no válida
   decidim:
     accountability:
       actions:
@@ -34,6 +42,16 @@ es:
         preview: Previsualizar
         title: Acciones
       admin:
+        imports:
+          create:
+            invalid: Ha habido un problema al importar este fichero
+            not_found: No se ha encontrado ningún resultado con result_id %{result_id}
+            success: El fichero ha sido importado correctamente
+          new:
+            errors: Errores
+            import: Importar
+            row_number: Fila
+            title: Importar resultados desde CSV
         models:
           result:
             name: Resultado
@@ -58,6 +76,7 @@ es:
             success: El resultado ha actualizado correctamente
         shared:
           subnav:
+            import_csv: Import CSV
             results: Resultados
             statuses: Estados
             template_texts: Template Texts

--- a/db/migrate/20170606102902_add_index_to_accountability_results_on_external_id.rb
+++ b/db/migrate/20170606102902_add_index_to_accountability_results_on_external_id.rb
@@ -1,0 +1,5 @@
+class AddIndexToAccountabilityResultsOnExternalId < ActiveRecord::Migration[5.0]
+  def change
+    add_index :decidim_accountability_results, [:decidim_feature_id, :external_id], unique: true, name: :decidim_accountability_results_on_external_id
+  end
+end

--- a/doc/csv_importer.md
+++ b/doc/csv_importer.md
@@ -1,0 +1,81 @@
+## How to use the CSV importer
+
+Upload a CSV file with the following headers:
+
+- `result_id`
+- `decidim_category_id`
+- `decidim_scope_id`
+- `parent_id`
+- `external_id`
+- `parent_external_id`
+- `start_date`
+- `end_date`
+- `decidim_accountability_status_id`
+- `progress`
+- `title_ca`
+- `title_es`
+- `title_en`
+- `description_ca`
+- `description_es`
+- `description_en`
+
+You can download `empty_example.csv` from this folder and fill it with your data. 
+
+If there's any error on any of the CSV rows the file will not be imported at all. You will get the error messages so you can fix the file and upload it again.  
+
+### Description of CSV columns
+
+#### `result_id` 
+It's the internal ID of the result in Decidim.
+
+If it's present the importer will try to find the result with that ID and update it. If the result with that ID is not found you will get an error.
+
+If it's not present (and there's no value for `external_id` in this row, as explained later) the importer will try to create a new result.
+
+
+#### `decidim_category_id`
+ID in Decidim of the category for this result
+
+
+#### `decidim_scope_id`
+ID in Decidim of the scope for this result
+
+
+#### `parent_id`
+If this result belongs to another result, the ID of the parent result.
+
+
+#### `external_id`
+An ID for this result that is used in an external system, for example the city council project tracking system.
+
+If this column has a value and the `result_id` column doesn't have one, the importer will try to find the result with this `external_id` and update it with the values of this row. If it's not found it will create a new result.
+
+
+#### `parent_external_id`
+This doesn't correspond to a field in the result for this row, it's meant to complement the `parent_id` column. When `parent_id` is not present in this row but `parent_external_id` is, it will be used to look for the parent result for this row by its `external_id` and set it as the parent for this row result.
+
+
+#### `start_date`
+Start date, in a format parseable by `Date.parse`, for example DD/MM/YYYY.
+
+
+#### `end_date`
+End date, in a format parseable by `Date.parse`, for example DD/MM/YYYY.
+
+
+#### `decidim_accountability_status_id`
+ID in Decidim of the Status for this result
+
+
+#### `progress`
+Number representing the progress for this result. 
+
+If the status set for this row has an associated progress value progress for this result will be set to that, ignoring this value.
+
+For results that have children the progress will be calculated and stored as the mean of all its children, and this value will have no effect.
+
+
+#### `title` and `description`
+For the  `title` and `description` columns you should add one column per available locale, with the `_locale` suffix. You need at least the values for the default locale. The values for the default locale will be copied to the missing ones.
+
+

--- a/doc/csv_importer.md
+++ b/doc/csv_importer.md
@@ -19,7 +19,7 @@ Upload a CSV file with the following headers:
 - `description_es`
 - `description_en`
 
-You can download `empty_example.csv` from this folder and fill it with your data. 
+You can download [empty_example.csv](empty_example.csv) from this folder and fill it with your data. 
 
 If there's any error on any of the CSV rows the file will not be imported at all. You will get the error messages so you can fix the file and upload it again.  
 
@@ -30,7 +30,7 @@ It's the internal ID of the result in Decidim.
 
 If it's present the importer will try to find the result with that ID and update it. If the result with that ID is not found you will get an error.
 
-If it's not present (and there's no value for `external_id` in this row, as explained later) the importer will try to create a new result.
+If it desn't have a value (and there's no value for `external_id` in this row, as explained later) the importer will try to create a new result.
 
 
 #### `decidim_category_id`

--- a/doc/empty_example.csv
+++ b/doc/empty_example.csv
@@ -1,0 +1,1 @@
+result_id,decidim_category_id,decidim_scope_id,parent_id,external_id,parent_external_id,start_date,end_date,decidim_accountability_status_id,progress,title_ca,title_es,title_en,description_ca,description_es,description_en

--- a/lib/decidim/accountability/admin_engine.rb
+++ b/lib/decidim/accountability/admin_engine.rb
@@ -14,6 +14,7 @@ module Decidim
         resource :template_texts
         resources :statuses
         resources :results
+        resource :import, only: [:new, :create]
         root to: "results#index"
       end
 

--- a/lib/decidim/accountability/test/factories.rb
+++ b/lib/decidim/accountability/test/factories.rb
@@ -31,8 +31,8 @@ FactoryGirl.define do
     feature { build(:feature, manifest_name: "accountability") }
     title { Decidim::Faker::Localized.sentence(3) }
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
-    start_date { Date.yesterday }
-    end_date { Date.tomorrow }
+    start_date { "12/7/2017" }
+    end_date { "30/9/2017" }
     status { create :accountability_status, feature: feature }
     progress { rand(1..100) }
   end

--- a/spec/forms/result_form_spec.rb
+++ b/spec/forms/result_form_spec.rb
@@ -22,9 +22,12 @@ describe Decidim::Accountability::Admin::ResultForm do
   let(:scope_id) { scope.id }
   let(:category) { create :category, participatory_process: participatory_process }
   let(:category_id) { category.id }
-  let(:start_date) { Date.yesterday }
-  let(:end_date) { Date.tomorrow }
+  let(:parent) { create :accountability_result, scope: scope, feature: current_feature }
+  let(:parent_id) { parent.id }
+  let(:start_date) { "12/3/2017" }
+  let(:end_date) { "21/6/2017" }
   let(:status) { create :accountability_status, feature: current_feature, key: "ongoing", name: { en: "Ongoing" } }
+  let(:status_id) { status.id }
   let(:progress) { 89 }
   let(:external_id) { "ID_in_other_system" }
 
@@ -32,11 +35,12 @@ describe Decidim::Accountability::Admin::ResultForm do
     {
       decidim_scope_id: scope_id,
       decidim_category_id: category_id,
+      parent_id: parent_id,
       title_en: title[:en],
       description_en: description[:en],
       start_date: start_date,
       end_date: end_date,
-      decidim_accountability_status_id: status.id,
+      decidim_accountability_status_id: status_id,
       progress: progress,
       external_id: external_id
     }
@@ -66,6 +70,25 @@ describe Decidim::Accountability::Admin::ResultForm do
 
   describe "when the category does not exist" do
     let(:category_id) { category.id + 10 }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  describe "when the parent does not exist" do
+    let(:parent_id) { parent.id + 10 }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  describe "when the status does not exist" do
+    let(:status_id) { status.id + 10 }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  describe "when external_id is already taken" do
+    let!(:existing_result) { create(:accountability_result, feature: current_feature, external_id: "some_id") }
+    let(:external_id) { "some_id" }
 
     it { is_expected.not_to be_valid }
   end

--- a/spec/services/csv_importer_spec.rb
+++ b/spec/services/csv_importer_spec.rb
@@ -8,6 +8,8 @@ describe Decidim::Accountability::CSVImporter do
   let(:current_feature) { create :feature, participatory_process: participatory_process, manifest_name: "accountability" }
   let!(:scope) { create :scope, organization: organization }
   let!(:category) { create :category, participatory_process: participatory_process }
+  let!(:status_1) { create :accountability_status, feature: current_feature, progress: nil }
+  let!(:status_2) { create :accountability_status, feature: current_feature, progress: 17 }
   let!(:result) { create :accountability_result, scope: scope, feature: current_feature, id: 123 }
   let!(:ext_result) { create :accountability_result, scope: scope, feature: current_feature, external_id: "existing_external_id" }
 
@@ -78,7 +80,9 @@ describe Decidim::Accountability::CSVImporter do
         expect(result.parent).to_not be_present
         expect(result.start_date).to eq(Date.new(2017,6,28))
         expect(result.end_date).to eq(Date.new(2017,8,30))
-        expect(result.progress).to eq(15)
+        expect(result.status).to be_present
+        expect(result.decidim_accountability_status_id).to eq(2)
+        expect(result.progress).to eq(17)
         expect(result.title).to eq("ca"=>"Existing Title in Catalan", "en"=>"Existing Title in English", "es"=>"Existing Title in Spanish")
       end
 

--- a/spec/services/csv_importer_spec.rb
+++ b/spec/services/csv_importer_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Accountability::CSVImporter do
+  let(:organization) { create(:organization) }
+  let(:participatory_process) { create(:participatory_process, :with_steps, organization: organization) }
+  let(:current_feature) { create :feature, participatory_process: participatory_process, manifest_name: "accountability" }
+  let!(:scope) { create :scope, organization: organization }
+  let!(:category) { create :category, participatory_process: participatory_process }
+  let!(:result) { create :accountability_result, scope: scope, feature: current_feature, id: 123 }
+  let!(:ext_result) { create :accountability_result, scope: scope, feature: current_feature, external_id: "existing_external_id" }
+
+  describe "import!" do
+    context "csv file with valid data" do
+      before(:each) do
+        csv_file_path = File.expand_path(File.join(File.dirname(__FILE__), "..", "support", "valid.csv"))
+        importer = Decidim::Accountability::CSVImporter.new(current_feature, csv_file_path)
+        @errors = importer.import!
+      end
+
+      it "returns empty errors" do
+        expect(@errors).to be_empty
+      end
+
+      it "updates existing result (with result_id)" do
+        result = Decidim::Accountability::Result.find_by(external_id: "ext_id_1")
+
+        expect(result).to be_present
+        expect(result.category).to be_present
+        expect(result.scope).to be_present
+        expect(result.parent).to_not be_present
+        expect(result.external_id).to eq("ext_id_1")
+        expect(result.start_date).to eq(Date.new(2017,5,20))
+        expect(result.end_date).to eq(Date.new(2017,6,30))
+        expect(result.progress).to eq(40) #mean value of children's progress
+        expect(result.title).to eq("ca" => "Salari bàsic de referència", "es" => "Salario básico de referencia", "en" => "Basic reference salary")
+      end
+
+      it "creates new child result" do
+        result = Decidim::Accountability::Result.find_by(external_id: "ext_id_2")
+
+        expect(result).to be_present
+        expect(result.category).to_not be_present
+        expect(result.scope).to_not be_present
+        expect(result.parent).to be_present
+        expect(result.parent_id).to eq(123)
+        expect(result.start_date).to eq(Date.new(2017,6,23))
+        expect(result.end_date).to eq(Date.new(2017,7,30))
+        expect(result.progress).to eq(40)
+        expect(result.title).to eq("ca"=>"Child title in Catalan", "en"=>"Child title in English", "es"=>"Child title in Spanish")
+        expect(result.description).to eq("ca"=>"Description in Catalan", "en"=>"Description in English", "es"=>"Description in Spanish")
+      end
+
+      it "creates new top level result" do
+        result = Decidim::Accountability::Result.find_by(external_id: "ext_id_3")
+
+        expect(result).to be_present
+        expect(result.scope).to be_present
+        expect(result.decidim_scope_id).to eq(1)
+        expect(result.category).to be_present
+        expect(result.decidim_category_id).to eq(1)
+        expect(result.start_date).to eq(Date.new(2017,6,23))
+        expect(result.end_date).to eq(Date.new(2017,7,30))
+        expect(result.status).to be_present
+        expect(result.decidim_accountability_status_id).to eq(1)
+        expect(result.progress).to eq(20) #mean value of children's progress
+        expect(result.title).to eq("ca"=>"Title in Catalan", "en"=>"Title in English", "es"=>"Title in Spanish")
+        expect(result.description).to eq("ca"=>"Description in Catalan", "en"=>"Description in English", "es"=>"Description in Spanish")
+      end
+
+      it "updates existing result (with external_id)" do
+        result = Decidim::Accountability::Result.find_by(external_id: "existing_external_id")
+
+        expect(result).to be_present
+        expect(result.category).to be_present
+        expect(result.scope).to be_present
+        expect(result.parent).to_not be_present
+        expect(result.start_date).to eq(Date.new(2017,6,28))
+        expect(result.end_date).to eq(Date.new(2017,8,30))
+        expect(result.progress).to eq(15)
+        expect(result.title).to eq("ca"=>"Existing Title in Catalan", "en"=>"Existing Title in English", "es"=>"Existing Title in Spanish")
+      end
+
+      it "creates new child result with parent_external_id" do
+        result = Decidim::Accountability::Result.find_by(external_id: "ext_id_child")
+
+        expect(result).to be_present
+        expect(result.category).to_not be_present
+        expect(result.scope).to_not be_present
+        expect(result.parent).to be_present
+        expect(result.parent.external_id).to eq("ext_id_3")
+        expect(result.start_date).to eq(Date.new(2017,8,28))
+        expect(result.end_date).to eq(Date.new(2017,11,30))
+        expect(result.progress).to eq(20)
+        expect(result.title).to eq("ca"=>"Child ext title in Catalan", "en"=>"Child ext title in English", "es"=>"Child ext title in Spanish")
+        expect(result.description).to eq("ca"=>"Description in Catalan", "en"=>"Description in English", "es"=>"Description in Spanish")
+      end
+    end
+
+    context "csv file with invalid data" do
+      it "doesn't change anything if any row is invalid" do
+        expect do
+          csv_file_path = File.expand_path(File.join(File.dirname(__FILE__), "..", "support", "invalid.csv"))
+          importer = Decidim::Accountability::CSVImporter.new(current_feature, csv_file_path)
+          errors = importer.import!
+        end.to_not change{ Decidim::Accountability::Result.count }
+      end
+
+      context "errors" do
+        before(:each) do
+          csv_file_path = File.expand_path(File.join(File.dirname(__FILE__), "..", "support", "invalid.csv"))
+          importer = Decidim::Accountability::CSVImporter.new(current_feature, csv_file_path)
+          @errors = importer.import!
+        end
+
+        it "returns error when result doesn't exist" do
+          expect(@errors).to include([9, ["No result found with result_id 1111"]])
+        end
+
+        it "returns error when dates are invalid" do
+          expect(@errors).to include([2, ["Start date is invalid", "End date is invalid"]])
+        end
+
+        it "returns error when parent is invalid (id doesn't exist)" do
+          expect(@errors).to include([5, ["Parent can't be blank"]])
+        end
+
+        it "returns error when status is invalid (id doesn't exist)" do
+          expect(@errors).to include([6, ["Status can't be blank"]])
+        end
+
+        it "returns error when scope is invalid (id doesn't exist)" do
+          expect(@errors).to include([8, ["Scope can't be blank"]])
+        end
+
+        it "returns error when category is invalid (id doesn't exist)" do
+          expect(@errors).to include([7, ["Category can't be blank"]])
+        end
+
+        it "returns error when external_id is already taken" do
+          expect(@errors).to include([10, ["External ID has already been taken"]])
+        end
+      end
+    end
+  end
+end

--- a/spec/services/csv_importer_spec.rb
+++ b/spec/services/csv_importer_spec.rb
@@ -37,6 +37,7 @@ describe Decidim::Accountability::CSVImporter do
         expect(result.end_date).to eq(Date.new(2017,6,30))
         expect(result.progress).to eq(40) #mean value of children's progress
         expect(result.title).to eq("ca" => "Salari bàsic de referència", "es" => "Salario básico de referencia", "en" => "Basic reference salary")
+        expect(result.description).to eq("ca"=>"Description in Catalan", "en"=>"Description in English", "es"=>"Description in English")
       end
 
       it "creates new child result" do
@@ -50,7 +51,7 @@ describe Decidim::Accountability::CSVImporter do
         expect(result.start_date).to eq(Date.new(2017,6,23))
         expect(result.end_date).to eq(Date.new(2017,7,30))
         expect(result.progress).to eq(40)
-        expect(result.title).to eq("ca"=>"Child title in Catalan", "en"=>"Child title in English", "es"=>"Child title in Spanish")
+        expect(result.title).to eq("ca"=>"Child title in Catalan", "en"=>"Child title in English", "es"=>"Child title in English")
         expect(result.description).to eq("ca"=>"Description in Catalan", "en"=>"Description in English", "es"=>"Description in Spanish")
       end
 

--- a/spec/support/invalid.csv
+++ b/spec/support/invalid.csv
@@ -3,7 +3,7 @@ result_id,decidim_category_id,decidim_scope_id,parent_id,external_id,parent_exte
 ,,,123,ext_id_2,20/06/2017,30/7/2017,1,10,Child title in Catalan,Child title in Spanish,Child title in English,Description in Catalan,Description in Spanish,Description in English
 ,1,1,,ext_id_3,,20/06/2017,30/7/2017,1,10,Title in Catalan,Title in Spanish,Title in English,Description in Catalan,Description in Spanish,Description in English
 ,,,234,ext_id_4,,20/06/2017,30/7/2017,1,10,Title in Catalan,Title in Spanish,Title in English,Description in Catalan,Description in Spanish,Description in English
-,1,1,,ext_id_5,,20/06/2017,30/7/2017,4,10,Title in Catalan,Title in Spanish,Title in English,Description in Catalan,Description in Spanish,Description in English
+,1,1,,ext_id_5,,20/06/2017,30/7/2017,9,10,Title in Catalan,Title in Spanish,Title in English,Description in Catalan,Description in Spanish,Description in English
 ,7,1,,ext_id_6,,20/06/2017,30/7/2017,1,10,Title in Catalan,Title in Spanish,Title in English,Description in Catalan,Description in Spanish,Description in English
 ,1,9,,ext_id_7,,20/06/2017,30/7/2017,1,10,Title in Catalan,Title in Spanish,Title in English,Description in Catalan,Description in Spanish,Description in English
 1111,1,1,,ext_id_1,,20/05/2017,30/6/2017,2,80,Salari bàsic de referència,Salario básico de referencia,Descrition in catalan,Description in spanish

--- a/spec/support/invalid.csv
+++ b/spec/support/invalid.csv
@@ -1,0 +1,10 @@
+result_id,decidim_category_id,decidim_scope_id,parent_id,external_id,parent_external_id,start_date,end_date,decidim_accountability_status_id,progress,title_ca,title_es,title_en,description_ca,description_es,description_en
+123,1,1,,ext_id_1,,40/05/2017,30/13/2017,1,80,Salari bàsic de referència,Salario básico de referencia,Basic reference salary,Description in Catalan,Description in Spanish,Description in English
+,,,123,ext_id_2,20/06/2017,30/7/2017,1,10,Child title in Catalan,Child title in Spanish,Child title in English,Description in Catalan,Description in Spanish,Description in English
+,1,1,,ext_id_3,,20/06/2017,30/7/2017,1,10,Title in Catalan,Title in Spanish,Title in English,Description in Catalan,Description in Spanish,Description in English
+,,,234,ext_id_4,,20/06/2017,30/7/2017,1,10,Title in Catalan,Title in Spanish,Title in English,Description in Catalan,Description in Spanish,Description in English
+,1,1,,ext_id_5,,20/06/2017,30/7/2017,4,10,Title in Catalan,Title in Spanish,Title in English,Description in Catalan,Description in Spanish,Description in English
+,7,1,,ext_id_6,,20/06/2017,30/7/2017,1,10,Title in Catalan,Title in Spanish,Title in English,Description in Catalan,Description in Spanish,Description in English
+,1,9,,ext_id_7,,20/06/2017,30/7/2017,1,10,Title in Catalan,Title in Spanish,Title in English,Description in Catalan,Description in Spanish,Description in English
+1111,1,1,,ext_id_1,,20/05/2017,30/6/2017,2,80,Salari bàsic de referència,Salario básico de referencia,Descrition in catalan,Description in spanish
+123,1,1,,existing_external_id,,1/6/2018,10/7/2018,1,10,Dup Title in Catalan,Dup Title in Spanish,Dup Title in English,Description in Catalan,Description in Spanish,Description in English

--- a/spec/support/valid.csv
+++ b/spec/support/valid.csv
@@ -2,5 +2,5 @@ result_id,decidim_category_id,decidim_scope_id,parent_id,external_id,parent_exte
 123,1,1,,ext_id_1,,20/05/2017,30/6/2017,,,Salari bàsic de referència,Salario básico de referencia,Basic reference salary,Description in Catalan,Description in Spanish,Description in English
 ,,,123,ext_id_2,,23/06/2017,30/7/2017,1,40,Child title in Catalan,Child title in Spanish,Child title in English,Description in Catalan,Description in Spanish,Description in English
 ,1,1,,ext_id_3,,23/06/2017,30/7/2017,1,,Title in Catalan,Title in Spanish,Title in English,Description in Catalan,Description in Spanish,Description in English
-,1,1,,existing_external_id,,28/06/2017,30/8/2017,1,15,Existing Title in Catalan,Existing Title in Spanish,Existing Title in English,Description in Catalan,Description in Spanish,Description in English
+,1,1,,existing_external_id,,28/06/2017,30/8/2017,2,15,Existing Title in Catalan,Existing Title in Spanish,Existing Title in English,Description in Catalan,Description in Spanish,Description in English
 ,,,,ext_id_child,ext_id_3,28/08/2017,30/11/2017,1,20,Child ext title in Catalan,Child ext title in Spanish,Child ext title in English,Description in Catalan,Description in Spanish,Description in English

--- a/spec/support/valid.csv
+++ b/spec/support/valid.csv
@@ -1,0 +1,6 @@
+result_id,decidim_category_id,decidim_scope_id,parent_id,external_id,parent_external_id,start_date,end_date,decidim_accountability_status_id,progress,title_ca,title_es,title_en,description_ca,description_es,description_en
+123,1,1,,ext_id_1,,20/05/2017,30/6/2017,,,Salari bàsic de referència,Salario básico de referencia,Basic reference salary,Description in Catalan,Description in Spanish,Description in English
+,,,123,ext_id_2,,23/06/2017,30/7/2017,1,40,Child title in Catalan,Child title in Spanish,Child title in English,Description in Catalan,Description in Spanish,Description in English
+,1,1,,ext_id_3,,23/06/2017,30/7/2017,1,,Title in Catalan,Title in Spanish,Title in English,Description in Catalan,Description in Spanish,Description in English
+,1,1,,existing_external_id,,28/06/2017,30/8/2017,1,15,Existing Title in Catalan,Existing Title in Spanish,Existing Title in English,Description in Catalan,Description in Spanish,Description in English
+,,,,ext_id_child,ext_id_3,28/08/2017,30/11/2017,1,20,Child ext title in Catalan,Child ext title in Spanish,Child ext title in English,Description in Catalan,Description in Spanish,Description in English

--- a/spec/support/valid.csv
+++ b/spec/support/valid.csv
@@ -1,6 +1,6 @@
 result_id,decidim_category_id,decidim_scope_id,parent_id,external_id,parent_external_id,start_date,end_date,decidim_accountability_status_id,progress,title_ca,title_es,title_en,description_ca,description_es,description_en
-123,1,1,,ext_id_1,,20/05/2017,30/6/2017,,,Salari bàsic de referència,Salario básico de referencia,Basic reference salary,Description in Catalan,Description in Spanish,Description in English
-,,,123,ext_id_2,,23/06/2017,30/7/2017,1,40,Child title in Catalan,Child title in Spanish,Child title in English,Description in Catalan,Description in Spanish,Description in English
+123,1,1,,ext_id_1,,20/05/2017,30/6/2017,,,Salari bàsic de referència,Salario básico de referencia,Basic reference salary,Description in Catalan,,Description in English
+,,,123,ext_id_2,,23/06/2017,30/7/2017,1,40,Child title in Catalan,,Child title in English,Description in Catalan,Description in Spanish,Description in English
 ,1,1,,ext_id_3,,23/06/2017,30/7/2017,1,,Title in Catalan,Title in Spanish,Title in English,Description in Catalan,Description in Spanish,Description in English
 ,1,1,,existing_external_id,,28/06/2017,30/8/2017,2,15,Existing Title in Catalan,Existing Title in Spanish,Existing Title in English,Description in Catalan,Description in Spanish,Description in English
 ,,,,ext_id_child,ext_id_3,28/08/2017,30/11/2017,1,20,Child ext title in Catalan,Child ext title in Spanish,Child ext title in English,Description in Catalan,Description in Spanish,Description in English


### PR DESCRIPTION
This PR implements a CSV importer for the admin interface.

It imports results, either first level, which belong to a process category or child results, which belong to another result. 

For details about how to create a valid CSV see doc/csv_importer.md