### PR TITLE
Better result page styles

### DIFF
--- a/app/assets/stylesheets/decidim/accountability/accountability/_results.scss
+++ b/app/assets/stylesheets/decidim/accountability/accountability/_results.scss
@@ -72,17 +72,20 @@
 
 .result-view {
   .title {
+    display: flex;
+    align-items: flex-start;
     margin-bottom: 1rem;
 
     .icon {
       fill: $secondary;
       width: 1.5rem;
       height: 1.5rem;
-      margin-right: 0.25rem;
+      margin-right: 0.75rem;
+      margin-top: 0.5rem;
     }
 
     h2 {
-      display: inline-block;
+      display: inline;
     }
   }
 
@@ -109,6 +112,10 @@
       }
     }
   }
+  
+  .result-description div {
+    margin-bottom: 1rem;
+  }
 
   .result-meta {
     margin-bottom: 0.5rem;
@@ -116,7 +123,7 @@
 
     .result-meta--label {
       display: inline-block;
-      width: 50%;
+      width: 30%;
       font-weight: 600;
       color: lighten($dark-gray, 30);
     }

--- a/app/assets/stylesheets/decidim/accountability/accountability/_results.scss
+++ b/app/assets/stylesheets/decidim/accountability/accountability/_results.scss
@@ -75,17 +75,22 @@
     display: flex;
     align-items: flex-start;
     margin-bottom: 1rem;
+    flex-direction: column;
 
     .icon {
       fill: $secondary;
       width: 1.5rem;
       height: 1.5rem;
-      margin-right: 0.75rem;
-      margin-top: 0.5rem;
+      margin-bottom: 0.5rem;
+      
+      @include breakpoint(medium) {
+        margin-right: 0.75rem;
+        margin-top: 0.5rem;
+      }
     }
-
-    h2 {
-      display: inline;
+    
+    @include breakpoint(medium) {
+      flex-direction: row;
     }
   }
 

--- a/app/assets/stylesheets/decidim/accountability/accountability/_results.scss
+++ b/app/assets/stylesheets/decidim/accountability/accountability/_results.scss
@@ -122,13 +122,10 @@
     font-size: 1.25rem;
 
     .result-meta--label {
-      display: inline-block;
-      width: 30%;
       font-weight: 600;
       color: lighten($dark-gray, 30);
     }
     .result-meta--data {
-      display: inline-block;
       font-size: 1.15rem;
     }
   }

--- a/app/views/decidim/accountability/results/_show_leaf.html.erb
+++ b/app/views/decidim/accountability/results/_show_leaf.html.erb
@@ -19,12 +19,12 @@
           </div>
 
           <div class="progress">
-            <div class="progress-meter" style="width:<%= display_percentage result.progress %>"></div>
+            <div class="progress-meter" style="width:<%= result.progress %>%"></div>
           </div>
         </div>
       </div>
 
-      <div class="columns mediumlarge-3 mediumlarge-pull-5 end">
+      <div class="columns mediumlarge-6 mediumlarge-pull-5 end">
         <div class="section">
           <div class="result-meta">
             <% if result.start_date %>
@@ -59,7 +59,7 @@
       <div class="small-12 columns">
         <hr>
 
-        <div class="section">
+        <div class="section result-description">
           <%== translated_attribute result.description %>
           <%= render partial: "tags", locals: { result: result } %>
         </div>

--- a/app/views/decidim/accountability/results/_show_leaf.html.erb
+++ b/app/views/decidim/accountability/results/_show_leaf.html.erb
@@ -24,33 +24,33 @@
         </div>
       </div>
 
-      <div class="columns mediumlarge-6 mediumlarge-pull-5 end">
+      <div class="columns mediumlarge-5 mediumlarge-pull-5 end">
         <div class="section">
-          <div class="result-meta">
+          <div class="result-meta row">
             <% if result.start_date %>
-              <div class="result-meta--label"><%= t("models.result.fields.start_date", scope: "decidim.accountability") %></div>
-              <div class="result-meta--data"><%= result.start_date %></div>
+              <div class="result-meta--label medium-4 columns"><%= t("models.result.fields.start_date", scope: "decidim.accountability") %></div>
+              <div class="result-meta--data medium-8 columns"><%= result.start_date %></div>
             <% end %>
           </div>
 
-          <div class="result-meta">
+          <div class="result-meta row">
             <% if result.end_date %>
-              <div class="result-meta--label"><%= t("models.result.fields.end_date", scope: "decidim.accountability") %></div>
-              <div class="result-meta--data"><%= result.end_date %></div>
+              <div class="result-meta--label medium-4 columns"><%= t("models.result.fields.end_date", scope: "decidim.accountability") %></div>
+              <div class="result-meta--data medium-8 columns"><%= result.end_date %></div>
             <% end %>
           </div>
 
-          <div class="result-meta">
+          <div class="result-meta row">
             <% if result.status %>
-              <div class="result-meta--label"><%= t("models.result.fields.status", scope: "decidim.accountability") %></div>
-              <div class="result-meta--data"><%= translated_attribute(result.status.name) %></div>
+              <div class="result-meta--label medium-4 columns"><%= t("models.result.fields.status", scope: "decidim.accountability") %></div>
+              <div class="result-meta--data medium-8 columns"><%= translated_attribute(result.status.name) %></div>
             <% end %>
           </div>
 
-          <div class="result-meta">
+          <div class="result-meta row">
             <% if result.status && translated_attribute(result.status.description).present? %>
-              <div class="result-meta--label"><%= t("models.status.fields.description", scope: "decidim.accountability") %></div>
-              <div class="result-meta--data"><%= translated_attribute(result.status.description) %></div>
+              <div class="result-meta--label medium-4 columns"><%= t("models.status.fields.description", scope: "decidim.accountability") %></div>
+              <div class="result-meta--data medium-8 columns"><%= translated_attribute(result.status.description) %></div>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
This PR is connected with #38.

It fixes several issues that were showing up in the result page. The result title wasn't wrapping correctly when it was long, and there wasn't enough space for the status descriptions.

It also adds a small margin to the result description, which was overlapping with the tags, and fixes the progress meter display.

