### PR TITLE
Fix condition to skip category when subcategories are empty

### DIFF
--- a/app/views/decidim/accountability/results/_home_categories.html.erb
+++ b/app/views/decidim/accountability/results/_home_categories.html.erb
@@ -21,7 +21,7 @@
     <div class="row">
       <div class="small-12 columns">
         <% first_class_categories.each do |category| %>
-          <% next unless (category_results_count = count_calculator(current_scope, category.id)) > 0 || category.subcategories.size > 0 %>
+          <% next if (category_results_count = count_calculator(current_scope, category.id)) == 0 || category.subcategories.empty? %>
           <div class="categories--group row">
             <div class="category--section small-12 medium-4 columns">
               <div class="category--title">


### PR DESCRIPTION
Unexpected

This PR fixes the condition to skip a category implemented in #43